### PR TITLE
feat: collapsible sidebar and log analysis results

### DIFF
--- a/src/components/AnalysisSidebar.tsx
+++ b/src/components/AnalysisSidebar.tsx
@@ -3,14 +3,17 @@ import React, { useState, useMemo, useEffect } from 'react';
 import {
   Sidebar,
   SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
 import { 
   BarChart3, 
   TrendingUp, 
@@ -208,32 +211,38 @@ export const AnalysisSidebar: React.FC<AnalysisSidebarProps> = ({
             未找到匹配的分析方法
           </div>
         ) : (
-          filteredCategories.map((category) => (
-            <SidebarGroup key={category.label}>
-              <SidebarGroupLabel className="text-xs font-semibold text-gray-600 px-2 py-2">
-                {category.label}
-              </SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {category.items.map((item) => (
-                    <SidebarMenuItem key={item.key}>
-                      <SidebarMenuButton 
-                        onClick={() => onSelectAnalysis(item.key)}
-                        className={`w-full justify-start text-sm py-2 px-2 ${
-                          selectedAnalysis === item.key 
-                            ? 'bg-blue-100 text-blue-700' 
-                            : 'hover:bg-gray-100'
-                        }`}
-                      >
-                        <item.icon className="h-4 w-4 mr-2" />
-                        <span>{item.title}</span>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  ))}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ))
+          <Accordion
+            type="multiple"
+            defaultValue={filteredCategories.map((c) => c.label)}
+            className="w-full"
+          >
+            {filteredCategories.map((category) => (
+              <AccordionItem key={category.label} value={category.label}>
+                <AccordionTrigger className="text-xs font-semibold text-gray-600 px-2 py-2">
+                  {category.label}
+                </AccordionTrigger>
+                <AccordionContent className="px-0">
+                  <SidebarMenu>
+                    {category.items.map((item) => (
+                      <SidebarMenuItem key={item.key}>
+                        <SidebarMenuButton
+                          onClick={() => onSelectAnalysis(item.key)}
+                          className={`w-full justify-start text-sm py-2 px-2 ${
+                            selectedAnalysis === item.key
+                              ? 'bg-blue-100 text-blue-700'
+                              : 'hover:bg-gray-100'
+                          }`}
+                        >
+                          <item.icon className="h-4 w-4 mr-2" />
+                          <span>{item.title}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
         )}
       </SidebarContent>
     </Sidebar>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -78,6 +78,33 @@ export type Database = {
         }
         Relationships: []
       }
+      analysis_logs: {
+        Row: {
+          id: string
+          prompt: string
+          provider: string
+          model_id: string
+          result: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          prompt: string
+          provider: string
+          model_id: string
+          result?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          prompt?: string
+          provider?: string
+          model_id?: string
+          result?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           created_at: string

--- a/supabase/functions/analyze-data/index.ts
+++ b/supabase/functions/analyze-data/index.ts
@@ -108,8 +108,15 @@ serve(async (req) => {
         })
       } else {
         result = await response.json()
+        const text = result.choices[0]?.message?.content || '分析完成但未收到结果'
+        await supabaseClient.from('analysis_logs').insert({
+          prompt,
+          provider,
+          model_id,
+          result: text,
+        })
         return new Response(
-          JSON.stringify({ content: result.choices[0]?.message?.content || '分析完成但未收到结果' }),
+          JSON.stringify({ content: text }),
           { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         )
       }
@@ -187,8 +194,15 @@ serve(async (req) => {
         })
       } else {
         result = await response.json()
+        const text = result.content[0]?.text || '分析完成但未收到结果'
+        await supabaseClient.from('analysis_logs').insert({
+          prompt,
+          provider,
+          model_id,
+          result: text,
+        })
         return new Response(
-          JSON.stringify({ content: result.content[0]?.text || '分析完成但未收到结果' }),
+          JSON.stringify({ content: text }),
           { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         )
       }
@@ -303,8 +317,15 @@ serve(async (req) => {
         })
       } else {
         result = await response.json()
+        const text = result.choices[0]?.message?.content || '分析完成但未收到结果'
+        await supabaseClient.from('analysis_logs').insert({
+          prompt,
+          provider,
+          model_id,
+          result: text,
+        })
         return new Response(
-          JSON.stringify({ content: result.choices[0]?.message?.content || '分析完成但未收到结果' }),
+          JSON.stringify({ content: text }),
           { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         )
       }


### PR DESCRIPTION
## Summary
- make analysis sidebar groups collapsible using Accordion
- log analysis results into `analysis_logs` table in edge function
- update Supabase types for `analysis_logs`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6841b303fa88832794b6c91aa7b480be