### PR TITLE
Add algorithm info popovers

### DIFF
--- a/src/components/AnalysisSidebar.tsx
+++ b/src/components/AnalysisSidebar.tsx
@@ -24,10 +24,13 @@ import {
   FileText,
   Search,
   MoreHorizontal,
-  Menu
+  Menu,
+  Info
 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { algorithmInfo } from '@/lib/algorithmInfo';
 
 interface AnalysisSidebarProps {
   selectedAnalysis: string;
@@ -236,20 +239,51 @@ export const AnalysisSidebar: React.FC<AnalysisSidebarProps> = ({
                     </AccordionTrigger>
                     <AccordionContent className="px-0">
                       <div className="space-y-1">
-                        {category.items.map((item) => (
-                          <button
-                            key={item.key}
-                            onClick={() => onSelectAnalysis(item.key)}
-                            className={`w-full flex items-center justify-start text-sm py-2 px-2 rounded-md transition-colors ${
-                              selectedAnalysis === item.key
-                                ? 'bg-blue-100 text-blue-700'
-                                : 'hover:bg-gray-100'
-                            }`}
-                          >
-                            <item.icon className="h-4 w-4 mr-2" />
-                            <span>{item.title}</span>
-                          </button>
-                        ))}
+                        {category.items.map((item) => {
+                          const info = algorithmInfo[item.key as keyof typeof algorithmInfo];
+                          return (
+                            <div key={item.key} className="flex items-center justify-between">
+                              <button
+                                onClick={() => onSelectAnalysis(item.key)}
+                                className={`flex-1 flex items-center justify-start text-sm py-2 px-2 rounded-md transition-colors ${
+                                  selectedAnalysis === item.key
+                                    ? 'bg-blue-100 text-blue-700'
+                                    : 'hover:bg-gray-100'
+                                }`}
+                              >
+                                <item.icon className="h-4 w-4 mr-2" />
+                                <span>{item.title}</span>
+                              </button>
+                              {info && (
+                                <Popover>
+                                  <PopoverTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="ml-1 h-5 w-5 p-0"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <Info className="h-4 w-4 text-gray-500" />
+                                    </Button>
+                                  </PopoverTrigger>
+                                  <PopoverContent className="w-80" onOpenAutoFocus={(e) => e.preventDefault()}>
+                                    <h4 className="font-medium mb-2">{info.title}</h4>
+                                    <p className="text-sm mb-2">{info.description}</p>
+                                    <p className="text-sm text-gray-600 mb-1">示例：{info.example}</p>
+                                    <div className="mb-1">
+                                      <p className="text-xs text-gray-500">数据样例：</p>
+                                      <pre className="whitespace-pre-wrap bg-gray-100 p-2 rounded text-xs">{info.sampleData}</pre>
+                                    </div>
+                                    <div>
+                                      <p className="text-xs text-gray-500">返回结果：</p>
+                                      <pre className="whitespace-pre-wrap bg-gray-100 p-2 rounded text-xs">{info.resultExample}</pre>
+                                    </div>
+                                  </PopoverContent>
+                                </Popover>
+                              )}
+                            </div>
+                          );
+                        })}
                       </div>
                     </AccordionContent>
                   </AccordionItem>

--- a/src/components/WorkArea.tsx
+++ b/src/components/WorkArea.tsx
@@ -26,49 +26,7 @@ interface WorkAreaProps {
   user: SupabaseUser | null;
 }
 
-// 分析方法配置
-const analysisConfig = {
-  frequency: {
-    title: '频数分析',
-    description: '统计数据中各值出现的频次',
-    example: '适用于分析问卷中选择题的分布情况'
-  },
-  crosstab: {
-    title: '交叉表分析',
-    description: '分析两个或多个分类变量之间的关系',
-    example: '适用于分析性别与购买偏好的关系'
-  },
-  descriptives: {
-    title: '描述性统计',
-    description: '计算均值、标准差、最大值、最小值等基本统计量',
-    example: '适用于了解数据的基本分布特征'
-  },
-  correlation: {
-    title: '相关性分析',
-    description: '分析变量之间的线性相关关系',
-    example: '适用于分析收入与消费支出的关系'
-  },
-  regression: {
-    title: '线性回归分析',
-    description: '建立因变量与自变量之间的线性关系模型',
-    example: '适用于预测房价与面积、位置等因素的关系'
-  },
-  anova: {
-    title: '方差分析',
-    description: '比较多个组之间的均值差异',
-    example: '适用于比较不同教学方法的效果差异'
-  },
-  ttest: {
-    title: 'T检验',
-    description: '比较两个组的均值是否存在显著差异',
-    example: '适用于比较两种药物的治疗效果'
-  },
-  reliability: {
-    title: '信度分析',
-    description: '评估问卷或量表的内部一致性',
-    example: '适用于验证问卷的可靠性'
-  }
-};
+import { algorithmInfo } from '@/lib/algorithmInfo';
 
 export const WorkArea: React.FC<WorkAreaProps> = ({ selectedAnalysis, uploadedData = [], user }) => {
   const [datasets, setDatasets] = useState<DataSet[]>([]);
@@ -142,7 +100,7 @@ export const WorkArea: React.FC<WorkAreaProps> = ({ selectedAnalysis, uploadedDa
       return;
     }
 
-    const analysisInfo = analysisConfig[selectedAnalysis as keyof typeof analysisConfig];
+    const analysisInfo = algorithmInfo[selectedAnalysis as keyof typeof algorithmInfo];
     const taskName = `${analysisInfo?.title || selectedAnalysis} - ${dataSourceName}`;
 
     // 添加到分析队列
@@ -218,7 +176,7 @@ export const WorkArea: React.FC<WorkAreaProps> = ({ selectedAnalysis, uploadedDa
     }
   };
 
-  const currentAnalysis = analysisConfig[selectedAnalysis as keyof typeof analysisConfig];
+  const currentAnalysis = algorithmInfo[selectedAnalysis as keyof typeof algorithmInfo];
 
   return (
     <div className="space-y-6">

--- a/src/lib/algorithmInfo.ts
+++ b/src/lib/algorithmInfo.ts
@@ -1,0 +1,66 @@
+export interface AlgorithmInfo {
+  title: string;
+  description: string;
+  example: string;
+  sampleData: string;
+  resultExample: string;
+}
+
+export const algorithmInfo: Record<string, AlgorithmInfo> = {
+  frequency: {
+    title: '频数分析',
+    description: '统计数据中各值出现的频次，用于查看离散变量的分布情况。',
+    example: '例如调查问卷中选项A、B、C的出现次数。',
+    sampleData: `value\nA\nB\nA\nC\nA`,
+    resultExample: `A: 3\nB: 1\nC: 1`
+  },
+  crosstab: {
+    title: '交叉表分析',
+    description: '用于分析两个或多个分类变量之间的关系。',
+    example: '例如比较性别与购买意向之间的联系。',
+    sampleData: `gender,intent\nM,Yes\nF,No\nM,Yes`,
+    resultExample: '生成包含各组合频次的交叉表'
+  },
+  descriptives: {
+    title: '描述性统计',
+    description: '计算均值、标准差、最大值、最小值等基本统计量。',
+    example: '适用于快速了解数据的集中趋势和离散程度。',
+    sampleData: `score\n12\n15\n11\n20`,
+    resultExample: '返回均值、标准差等统计指标'
+  },
+  correlation: {
+    title: '相关性分析',
+    description: '评估两个连续变量之间的线性相关程度。',
+    example: '例如收入与消费支出之间的关系。',
+    sampleData: `income,spend\n10,8\n12,9\n9,6`,
+    resultExample: '输出皮尔逊相关系数等数值'
+  },
+  regression: {
+    title: '线性回归分析',
+    description: '建立自变量与因变量之间的线性模型，用于预测和解释。',
+    example: '根据面积和位置预测房价。',
+    sampleData: `price,area\n100,80\n120,100\n150,120`,
+    resultExample: '给出回归系数、R^2等结果'
+  },
+  anova: {
+    title: '方差分析',
+    description: '比较三个及以上组的均值是否存在显著差异。',
+    example: '比较不同教学方法下考试成绩的差异。',
+    sampleData: `method,score\nA,80\nB,75\nA,85`,
+    resultExample: '返回F值和p值等信息'
+  },
+  ttest: {
+    title: 'T检验',
+    description: '检验两个样本均值的差异是否显著。',
+    example: '比较新旧药物的治疗效果。',
+    sampleData: `group,score\nnew,5\nold,3\nnew,6`,
+    resultExample: '返回t值和p值'
+  },
+  reliability: {
+    title: '信度分析',
+    description: '评估问卷或量表内部一致性，常用Cronbach α系数。',
+    example: '用于验证问卷题项是否可靠。',
+    sampleData: `q1,q2,q3\n3,4,5\n4,4,4\n5,5,5`,
+    resultExample: '输出Cronbach α值'
+  }
+};


### PR DESCRIPTION
## Summary
- create `algorithmInfo` with algorithm explanations and examples
- add info popovers to algorithm items in `AnalysisSidebar`
- use `algorithmInfo` in `WorkArea` for descriptions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ded0dbf883278a2553a838144cc2